### PR TITLE
修改obv11的消息存储，修复若干与gocq的兼容问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 config.yaml
 node_modules
 package-lock.json
+/lib

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     "koa-bodyparser": "^4.3.0",
     "log4js": "^6.5.2",
     "mime-types": "^2.1.35",
-    "ws": "^8.8.0"
+    "ws": "^8.8.0",
+    "better-sqlite3": "^8.6.0",
+    "reflect-metadata": "^0.1.13",
+    "typeorm": "^0.3.17"
   }
 }

--- a/src/config.sample.yaml
+++ b/src/config.sample.yaml
@@ -31,6 +31,8 @@ general: # 通用配置，在单个配置省略时的默认值
 # 每个账号的单独配置(用于覆盖通用配置)
 123456789:
   version: V11 # 使用的oneBot版本
+  password:'' # 账号密码，未配置则扫码登陆
+  group_whitelist: [] # 群消息派发白名单，只有数组中的群号才派发，为空则全部派发
   protocol: # 将会覆盖通用配置中的protocol
     platform: 1
   # 。。。其他配置项参见上方对应oneBot版本的通用配置

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,5 +1,6 @@
 import Koa from 'koa'
 import * as os from 'os'
+import "reflect-metadata";
 import {copyFileSync, existsSync, mkdirSync, writeFileSync} from "fs";
 import {Logger, getLogger} from "log4js";
 import {createServer, Server} from "http";

--- a/src/service/V11/action/common.ts
+++ b/src/service/V11/action/common.ts
@@ -1,4 +1,4 @@
-import {OnlineStatus} from "icqq";
+import {Message, OnlineStatus} from "icqq";
 import {OneBotStatus} from "@/onebot";
 import {V11} from "@/service/V11";
 
@@ -25,10 +25,15 @@ export class CommonAction {
      * 获取消息
      * @param message_id {string} 消息id
      */
-    getMsg(this: V11, message_id: string) {
-        return this.client.getMsg(message_id)
+    async getMsg(this: V11, message_id: number) {
+        if(message_id == 0) throw new Error('getMsg: message_id[0] is invalid')
+        let msg_entry = await this.db.getMsgById(message_id)
+        if(!msg_entry) throw new Error(`getMsg: can not find msg[${message_id}] in db`)
+        let msg: Message = await this.client.getMsg(msg_entry.base64_id)
+        msg.message_id = String(message_id)  // nonebot v11 要求 message_id 是 number 类型
+        msg["real_id"] = msg.message_id      // nonebot 的reply类型会检测real_id是否存在，虽然它从未使用
+        return msg
     }
-
 
     /**
      * 获取合并消息

--- a/src/service/V11/db_entities.ts
+++ b/src/service/V11/db_entities.ts
@@ -1,0 +1,37 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from "typeorm"
+
+@Entity()
+export class MsgEntry {
+    @PrimaryGeneratedColumn()
+    id?: number
+    
+    @Column()
+    base64_id: string   // message_id from icqq（此字段与消息并不是一一对应的，不能用来对比是否是同一条消息）
+
+    @Column()
+    seq: number         // 群聊每个群序号独立，因此不能用来做全局唯一id
+    
+    @Column()
+    user_id: number
+
+    @Column()
+    nickname: string
+    
+    @Column()
+    group_id: number    // for private msg it's 0
+
+    @Column()
+    group_name: string
+    
+    @Column({length: 1024})
+    content: string
+    
+    @Column({default:false})
+    recalled: boolean
+    
+    @CreateDateColumn()
+    create_time: Date
+    
+    @Column({nullable:true})
+    recall_time?: Date
+}

--- a/src/service/V11/db_sqlite.ts
+++ b/src/service/V11/db_sqlite.ts
@@ -1,0 +1,121 @@
+import {readFileSync, writeFileSync, existsSync} from "fs";
+import { MsgEntry } from "./db_entities"
+import { DataSource, Repository } from "typeorm";
+import { Logger } from "log4js";
+
+export class Database {
+    logger: Logger
+    dbPath: string
+    public dataSource: DataSource
+    /**
+     * 消息在数据库中的保留时间
+     */
+    public msgHistoryPreserveDays: number = 14 // 历史消息默认存储2周
+    public msgHistoryCheckInterval: number = 1 * 24 * 3600 * 1000 // 历史记录检查间隔
+    msgRepo: Repository<MsgEntry>
+
+    constructor(dbPath: string, logger: Logger){
+        this.dbPath = dbPath
+        this.logger = logger
+        
+        this.dataSource = new DataSource({
+            type: "better-sqlite3",
+            database: dbPath,
+            entities: [MsgEntry],
+        })
+
+        this.initDB()
+    }
+
+    async initDB() {
+        try {
+            await this.dataSource.initialize()
+            await this.dataSource.synchronize(false)
+        } catch(err) {
+            this.logger.error(`sqlite [${this.dbPath}] open fail!`, err)
+            return
+        }
+        
+        this.msgRepo = this.dataSource.getRepository(MsgEntry)
+        this.logger.debug(`sqlite [${this.dbPath}] open success`)
+
+        setInterval(() => {
+            this.shrinkDB()
+        }, this.msgHistoryCheckInterval);
+    }
+
+    /**
+     * 增加或更新一条消息到数据库
+     * @param msgData 
+     */
+    public async addOrUpdateMsg(msgData: MsgEntry): Promise<number> {
+        let msgDataExists = await this.getMsgByBase64Id(msgData.base64_id)
+        if(msgDataExists) {
+            msgData.id = msgDataExists.id
+            await this.msgRepo.update({id: msgData.id}, msgData)
+            return msgDataExists.id
+        }
+
+        msgData = await this.msgRepo.save(msgData)
+        this.logger.debug(`addMsg with id:${msgData.id}`)
+        return msgData.id
+    }
+
+    /**
+     * 通过 icqq 的 base64 格式的 message_id 获取一个 MsgData 对象
+     * @param base64_id 
+     * @returns 
+     */
+    public async getMsgByBase64Id(base64_id: string): Promise<MsgEntry | null> {
+        let ret = await this.msgRepo.findOneBy({base64_id: base64_id})
+        return ret
+    }
+
+    /**
+     * 通过 number 类型的 id 自增主键获取一个 MsgData 对象
+     * @param id 
+     * @returns 
+     */
+    public async getMsgById(id: number): Promise<MsgEntry | null> {
+        let ret = await this.msgRepo.findOneBy({id: id})
+        return ret
+    }
+
+    /**
+     * 通过参数从数据库中查找消息
+     * @param user_id 
+     * @param group_id 
+     * @param seq 
+     */
+    public async getMsgByParams(user_id: number, group_id: number, seq: number): Promise<MsgEntry | null> {
+        let ret = await this.msgRepo.findOneBy({user_id: user_id, group_id: group_id, seq: seq})
+        return ret
+    }
+
+    /**
+     * 将一条消息标记为 recalled
+     * @param base64_id 
+     * @param id 
+     */
+    public async markMsgAsRecalled(base64_id?: string, id?: number) {
+        if(base64_id || id)
+            await this.msgRepo.update(base64_id ? {base64_id: base64_id} : {id: id}, {recalled: true, recall_time: new Date()})
+        else
+            throw new Error("base64_id 或 id 参数至少一个应该被赋值")
+    }
+
+    /**
+     * 根据 `msgPreserveDays` 变量定义的保留期限收缩数据库
+     */
+    public async shrinkDB() {
+        let dt = new Date()
+        dt.setDate(dt.getDate() - this.msgHistoryPreserveDays)
+
+        await this.msgRepo
+        .createQueryBuilder()
+        .delete()
+        .from(MsgEntry)
+        .where("create_time < :dt", {dt: dt})
+        .execute()
+    }
+}

--- a/src/service/V11/utils.ts
+++ b/src/service/V11/utils.ts
@@ -8,7 +8,12 @@ export async function processMessage(this: Client, message: string|SegmentElem|S
     let quote = elements.find(e => e.type === 'reply') as QuoteElem
     if (quote) remove(elements, quote)
     let music= elements.find(e=>e.type==='music') as MusicElem
-    if(music) remove(elements,music)
+    if(music) {
+        remove(elements,music)
+        if(String(music.platform) === 'custom') {
+            music.platform = music['subtype'] // gocq 的平台数据存储在 subtype 内，兼容 icqq 时要求前端必须发送 id 字段
+        }
+    }
     let share= elements.find(e=>e.type==='share') as ShareElem
     if(share) remove(elements,share)
     for(const element of elements){

--- a/src/service/V12/index.ts
+++ b/src/service/V12/index.ts
@@ -352,7 +352,11 @@ export class V12 extends EventEmitter implements OneBot.Base {
         return V12.formatPayload(this.oneBot.uin, event, data as any)
     }
 
-    dispatch(data: Record<string, any>) {
+    system_online(data){
+
+    }
+
+    async dispatch(data: Record<string, any>) {
         const payload: V12.Payload<any> = {
             id: uuid(),
             impl: 'onebots',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,12 @@ export function omit<T, K extends keyof T>(source: T, keys?: Iterable<K>) {
     return result
 }
 
+/**
+ * 将驼峰命名替换为下划线分割命名
+ * @param name 
+ * @returns 
+ * @todo 是否应该改名 ToUnderLine()？
+ */
 export function toLine<T extends string>(name: T) {
     return name.replace(/([A-Z])/g, "_$1").toLowerCase()
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "module": "commonjs",
     "declaration": true,
     "esModuleInterop":true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
     "lib": [
       "es6",
       "dom"


### PR DESCRIPTION
+ `obv11`历史消息改为使用`sqlite`存储，并默认存储2周
* `obv11`消息派发支持群号过滤
* 上线打印好友和群信息
* 修正若干 `base64_id` 和 `number_id` 之间的转换问题
* 修正与`gocq`不兼容的`real_id`字段，网易云分享`platform`等问题
